### PR TITLE
Non artist artists

### DIFF
--- a/src/_includes/artist_li.liquid
+++ b/src/_includes/artist_li.liquid
@@ -9,7 +9,7 @@
 <li class="mobile">
     <img src="{{ post.data.img }}">
     <div>
-      <span>{{ post.title }} ({{ post.data.country }})</span>
+      <span>{{ post.title }}{% if post.data.country %} ({{ post.data.country }}){% endif %}</span>
     </div>
 {{ post.content }}
 </li>

--- a/src/_includes/artist_right.liquid
+++ b/src/_includes/artist_right.liquid
@@ -1,6 +1,6 @@
 <div id="{{ post.slug }}">
 <div class="artistcontent">
-<h2>{{ post.title }} ({{ post.data.country }})</h2>
+<h2>{{ post.title }}{% if post.data.country %} ({{ post.data.country }}){% endif %}</h2>
 {{ post.content }}
 </div>
 <div id="stickyspace"></div>

--- a/src/_includes/day_schedule.liquid
+++ b/src/_includes/day_schedule.liquid
@@ -5,11 +5,17 @@
   <tr>
     <td>{{ slot.time }}</td>
     {% assign schedule_artist = collections.posts.pages | where: "title", slot.artist | first %}
+    <!-- If no artist found, assume it is not an artist and just print the title -->
+    {% if schedule_artist == blank %}
+    <td>{{ slot.artist }}</td>
+    <!-- Otherwise render artist link -->
+    {% else %}
     <td>
       <a class="artist-link" data-slug="{{ schedule_artist.slug }}">
         {{ schedule_artist.title }}{% if schedule_artist.data.country %} ({{ schedule_artist.data.country }}){% endif %}
       </a>
     </td>
+    {% endif %}
   </tr>
   {% endfor %}
   <tr class="dj">

--- a/src/_includes/day_schedule.liquid
+++ b/src/_includes/day_schedule.liquid
@@ -7,7 +7,7 @@
     {% assign schedule_artist = collections.posts.pages | where: "title", slot.artist | first %}
     <td>
       <a class="artist-link" data-slug="{{ schedule_artist.slug }}">
-        {{ schedule_artist.title }} ({{ schedule_artist.data.country }})
+        {{ schedule_artist.title }}{% if schedule_artist.data.country %} ({{ schedule_artist.data.country }}){% endif %}
       </a>
     </td>
   </tr>


### PR DESCRIPTION
Allows adding a slot to the schedule without having a match in the list of artists.

Tested using the following diff:
```
diff --git a/src/_data/events.yml b/src/_data/events.yml
index eb32e78..c21e2c4 100644
--- a/src/_data/events.yml
+++ b/src/_data/events.yml
@@ -8,6 +8,14 @@
       doors: "18:30"
       dj: "FoEG DJ's until 22:00"
       schedule:
+        - time: "19:30"
+          artist: Barbara Skovmand
+        - time: "20:30"
+          artist: Alvin Curran
+        - time: "21:30"
+          artist: Eat
+        - time: "23:00"
+          artist: Grev Trold
     - name: FRIDAY
       date: "2022-11-03"
       doors: "17:00"
```

<img width="351" alt="Screenshot 2023-10-18 at 14 43 54" src="https://github.com/wonderfulspam/wonderfulspam.github.io/assets/3662366/6ac0f66f-f2b7-4892-b554-549a762b47a5">
