### PR TITLE
Add mobile burger menu (fixes #122)

### DIFF
--- a/src/_includes/header.liquid
+++ b/src/_includes/header.liquid
@@ -2,10 +2,15 @@
     <div id="header">
         <a href="/"><img class=logo src="/assets/img/logo.png"></a>
     </div>
-    <nav class="horis-menu-list">
+    <button id="burger-menu" class="burger-menu" aria-label="Toggle menu">
+        <span></span>
+        <span></span>
+        <span></span>
+    </button>
+    <nav class="horis-menu-list" id="main-nav">
          <a class="menu-item-link" href="/lineup">Lineup</a>
         <a class="menu-item-link" href="/about">About</a>
-        <a class="menu-item-link" href="https://billetto.dk/en/e/festival-of-endless-gratitude-2025-billetter-1634643?bref=eyJzIjoib3JnYW5pc2VyIiwibSI6InNoYXJlIiwiYyI6Im1hbmFnZV92aXNpdCIsImNvIjoiMSIsInQiOjE3NTYyNzk4MjJ9">Tickets</a> 
+        <a class="menu-item-link" href="https://billetto.dk/en/e/festival-of-endless-gratitude-2025-billetter-1634643?bref=eyJzIjoib3JnYW5pc2VyIiwibSI6InNoYXJlIiwiYyI6Im1hbmFnZV92aXNpdCIsImNvIjoiMSIsInQiOjE3NTYyNzk4MjJ9">Tickets</a>
        <!-- <a class="menu-item-link" href="/art">Art</a>
         <a class="menu-item-link" href="/schedule">Schedule</a>-->
         <a class="menu-item-link" href="/past">Past</a>

--- a/src/_sass/_header.scss
+++ b/src/_sass/_header.scss
@@ -67,22 +67,83 @@ a.menu-item-link, a.menu-item-link:visited {
   margin-left: 30px;
 }
 
-@media only screen and (max-width: 1000px) {
-  a.menu-item-link, a.menu-item-link:visited {
-    font-size: 20px;
+.burger-menu {
+  display: none;
+  flex-direction: column;
+  justify-content: space-around;
+  width: 30px;
+  height: 25px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  z-index: 1001;
+  position: fixed;
+  top: 40px;
+  right: 20px;
+
+  span {
+    width: 30px;
+    height: 3px;
+    background-color: $title-color;
+    transition: all 0.3s ease;
+    transform-origin: center;
   }
+
+  &.active span:nth-child(1) {
+    transform: rotate(45deg) translate(7px, 7px);
+  }
+
+  &.active span:nth-child(2) {
+    opacity: 0;
+  }
+
+  &.active span:nth-child(3) {
+    transform: rotate(-45deg) translate(7px, -7px);
+  }
+}
+
+@media only screen and (max-width: 1000px) {
+  .burger-menu {
+    display: flex;
+  }
+
   #horisontal-header {
     padding-left: 20px;
     padding-right: 20px;
   }
+
   #header {
     text-size-adjust: none;
     h1 {
       font-size: 50px;
     }
   }
-  .menu-item-link:not(:first-child) {
-    margin-left: 20px;
+
+  .horis-menu-list {
+    position: fixed;
+    top: 0;
+    left: -100%;
+    width: 70%;
+    height: 100vh;
+    background-color: rgba(219, 229, 228, 0.98);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-start;
+    padding-left: 40px;
+    transition: left 0.3s ease-in-out;
+    z-index: 1000;
+
+    &.active {
+      left: 0;
+    }
+  }
+
+  a.menu-item-link, a.menu-item-link:visited {
+    font-size: 32px;
+    margin-left: 0 !important;
+    margin-bottom: 30px;
   }
 }
 

--- a/src/assets/js/site.js
+++ b/src/assets/js/site.js
@@ -9,3 +9,33 @@ addCopyClickHandler = function(linkClassname, targetId) {
         }, false);
     }
 }
+
+// Mobile burger menu functionality
+document.addEventListener('DOMContentLoaded', function() {
+    const burgerMenu = document.getElementById('burger-menu');
+    const nav = document.getElementById('main-nav');
+
+    if (burgerMenu && nav) {
+        burgerMenu.addEventListener('click', function() {
+            burgerMenu.classList.toggle('active');
+            nav.classList.toggle('active');
+        });
+
+        // Close menu when clicking on a link
+        const menuLinks = nav.querySelectorAll('.menu-item-link');
+        menuLinks.forEach(function(link) {
+            link.addEventListener('click', function() {
+                burgerMenu.classList.remove('active');
+                nav.classList.remove('active');
+            });
+        });
+
+        // Close menu when clicking outside
+        document.addEventListener('click', function(event) {
+            if (!burgerMenu.contains(event.target) && !nav.contains(event.target)) {
+                burgerMenu.classList.remove('active');
+                nav.classList.remove('active');
+            }
+        });
+    }
+});


### PR DESCRIPTION
## Summary
Implements a mobile burger menu for screens under 1000px as requested in #122.

## Changes
- Added burger menu button with animated icon (three lines → X)
- Menu slides in from left with smooth transition
- Background color matches site background (rgba(219, 229, 228, 0.98))
- Navigation items displayed vertically with larger font
- Burger menu stays fixed at top-right corner when scrolling
- Menu closes when clicking a link or outside the menu area

## Test plan
- [x] Build site successfully
- [x] Test on mobile viewport (< 1000px)
- [x] Verify menu slides in/out smoothly
- [x] Verify burger icon animates to X when active
- [ ] Verify menu stays sticky when scrolling
- [ ] Verify menu closes when clicking links
- [ ] Verify menu closes when clicking outside

🤖 Generated with [Claude Code](https://claude.com/claude-code)