### PR TITLE
Add artist descriptions to schedule page

### DIFF
--- a/src/_includes/day_schedule.liquid
+++ b/src/_includes/day_schedule.liquid
@@ -11,9 +11,9 @@
     <!-- Otherwise render artist link -->
     {% else %}
     <td>
-      <!--<a class="artist-link" data-slug="{{ schedule_artist.slug }}">-->
+      <a class="artist-link" data-slug="{{ schedule_artist.slug }}">
         {{ schedule_artist.title }}{% if schedule_artist.data.country %}<span class="country">({{ schedule_artist.data.country }})</span>{% endif %}
-      <!--</a>-->
+      </a>
     </td>
     {% endif %}
   </tr>

--- a/src/assets/js/site.js
+++ b/src/assets/js/site.js
@@ -12,10 +12,10 @@ addCopyClickHandler = function(linkClassname, targetId) {
 
 addArtistDetailHandler = function(linkClassname) {
     let links = document.querySelectorAll(linkClassname);
-    let lineupList = document.getElementById('lineup-list');
+    let lineupList = document.getElementById('lineup-list') || document.getElementById('schedule-list');
     let artistDetail = document.getElementById('artist-detail');
     let artistDetailContent = document.getElementById('artist-detail-content');
-    let topBackButton = document.getElementById('back-to-lineup');
+    let topBackButton = document.getElementById('back-to-lineup') || document.getElementById('back-to-schedule');
     let scrollPosition = 0;
 
     // Function to handle back navigation

--- a/src/schedule.liquid
+++ b/src/schedule.liquid
@@ -2,11 +2,9 @@
 title: Schedule
 layout: default.liquid
 permalink: /schedule
-data:
-  classname: wide-left
 ---
 
-<div id="left-column">
+<div id="schedule-list">
 {% for event_data in site.data.events %}
 
   <h2>{{ event_data.name }}</h2>
@@ -17,9 +15,12 @@ data:
   </div>
 {% endfor %}
 </div>
-<div id="right-column">
+<div id="artist-detail" style="display: none;">
+  <div id="artist-detail-content">
+    <a id="back-to-schedule" class="back-button">← BACK</a>
+  </div>
 </div>
 {% include "artists_hidden.liquid" %}
 <script type="text/javascript">
-  addCopyClickHandler(".artist-link", "right-column");
+  addArtistDetailHandler(".artist-link");
 </script>


### PR DESCRIPTION
Fixes #130

Adds the same interactive artist detail functionality from the lineup page to the schedule page.

## Changes
- Modified schedule.liquid to use two-view pattern with artist detail display
- Updated JavaScript handler to work with both lineup and schedule pages
- Enabled clickable artist links in schedule tables
- Preserves scroll position when navigating back
- Includes two back buttons, escape key support, and image click navigation

Generated with [Claude Code](https://claude.ai/code)