### PR TITLE
Add scheduled time overlays with responsive mobile font size

### DIFF
--- a/src/_includes/artist_li.liquid
+++ b/src/_includes/artist_li.liquid
@@ -4,5 +4,19 @@
       <span>{{ post.title }}{% if post.data.country %}</span><span class="country">({{ post.data.country }}){% endif %}</span>
     </div>
     <img src="{{ post.data.img }}">
+    {% for event in site.data.events %}
+      {% for day in event.days %}
+        {% for slot in day.schedule %}
+          {% if slot.artist == post.title %}
+            {% assign day_name = day.name | upcase %}
+            {% assign text_color = "white" %}
+            {% if post.title == "Finlay Shakespeare" or post.title == "Heidemann / Mingot / Klint" %}
+              {% assign text_color = "black" %}
+            {% endif %}
+            <span class="artist-time-overlay" style="font-size: 14px; position: absolute; top: 5px; right: 5px; line-height: 12px; font-family: 'public'; color: {{ text_color }}; z-index: 10; text-align: right;">{{ day_name }}<br>{{ slot.time }}</span>
+          {% endif %}
+        {% endfor %}
+      {% endfor %}
+    {% endfor %}
   </a>
 </li>

--- a/src/_includes/artist_right.liquid
+++ b/src/_includes/artist_right.liquid
@@ -1,9 +1,23 @@
-<div id="{{ post.slug }}">
+<div id="{{ post.slug }}" data-artist-name="{{ post.title }}">
     <div class="artistcontent">
     {% if post.data.img %}
     <div class="artist-image-container">
         <h2>{{ post.title }}{% if post.data.country %}<span class="country">({{ post.data.country }})</span>{% endif %}</h2>
         <img src="{{ post.data.img }}">
+        {% for event in site.data.events %}
+          {% for day in event.days %}
+            {% for slot in day.schedule %}
+              {% if slot.artist == post.title %}
+                {% assign day_name = day.name | upcase %}
+                {% assign text_color = "white" %}
+                {% if post.title == "Finlay Shakespeare" or post.title == "Heidemann / Mingot / Klint" %}
+                  {% assign text_color = "black" %}
+                {% endif %}
+                <span class="artist-time-overlay-large" style="font-size: 20px; position: absolute; top: 5px; right: 5px; line-height: 18px; font-family: 'public'; color: {{ text_color }}; z-index: 10; text-align: right;">{{ day_name }}<br>{{ slot.time }}</span>
+              {% endif %}
+            {% endfor %}
+          {% endfor %}
+        {% endfor %}
 </div>
 {% endif %}
 {{ post.content }}

--- a/src/assets/css/style.scss
+++ b/src/assets/css/style.scss
@@ -877,6 +877,13 @@ iframe {
     overflow-x: hidden
   }
 
+  // Adjust scheduled time overlay font size for mobile
+  .artist-time-overlay,
+  .artist-time-overlay-large {
+    font-size: 18px !important;
+    line-height: 16px !important;
+  }
+
 
 
   html,

--- a/src/assets/js/site.js
+++ b/src/assets/js/site.js
@@ -44,10 +44,22 @@ addArtistDetailHandler = function(linkClassname) {
             artistDetailContent.appendChild(topBackButton);
             artistDetailContent.insertAdjacentHTML('beforeend', targetHtml);
 
+            // Detect artist name and apply black color to back buttons if needed
+            let artistContainer = document.getElementById(slug);
+            let artistName = artistContainer ? artistContainer.getAttribute('data-artist-name') : '';
+            let lightImageArtists = ['Finlay Shakespeare', 'Heidemann / Mingot / Klint'];
+            let isLightImage = lightImageArtists.includes(artistName);
+
             // Add click handlers to all back buttons (using class)
             let backButtons = document.querySelectorAll('.back-button');
             backButtons.forEach(function(btn) {
                 btn.addEventListener('click', goBack);
+                // Apply black color for artists with light images
+                if (isLightImage) {
+                    btn.style.color = 'black';
+                } else {
+                    btn.style.color = 'white';
+                }
             });
 
             // Add click handler to artist image


### PR DESCRIPTION
Fixes #133

## Changes
- Display full day names (THURSDAY, FRIDAY, SATURDAY) with scheduled times on artist images
- Artist list items (lineup overview) show times with 14px font
- Artist details (right column) show times with 20px font
- Both adjust to 18px font size for screens under 1000px via CSS media query
- Black text for Finlay Shakespeare and Heidemann / Mingot / Klint (light images)
- White text for all other artists
- Back buttons are black for artists with light-colored images
- Right-aligned text with proper z-index layering

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/wonderfulspam/wonderfulspam.github.io/actions/runs/18951465004) | [Branch: claude/issue-133-20251030-1839](https://github.com/wonderfulspam/wonderfulspam.github.io/tree/claude/issue-133-20251030-1839