### PR TITLE
Fix show_on_lineup field implementation

### DIFF
--- a/src/_defaults/posts.md
+++ b/src/_defaults/posts.md
@@ -8,6 +8,7 @@ data:
   alt_img: /assets/img/alt_image.png
   img: /assets/img/image.png
   country: DK
+  show_on_lineup: true
 ---
 
 Here is the description of the artist.

--- a/src/artists/2025/almalapilli.md
+++ b/src/artists/2025/almalapilli.md
@@ -7,6 +7,7 @@ categories:
 data:
   img: /assets/img/almalapilli.jpg
   country: IT
+  show_on_lineup: true
 ---
 ALMA LAPILLI is the new live project from STILL (Simone Trabucchi), born in collaboration with multi-instrumentalist Raffaele Cardone and Vesuvian tammorra singer Romeo Barbaro. Conceived in Napoli, within the storied walls of Auditorium Novecento, it grows like a living archive of sounds, rooted in place, yet reaching beyond it.
 

--- a/src/artists/2025/camilleheltharder.md
+++ b/src/artists/2025/camilleheltharder.md
@@ -7,6 +7,7 @@ categories:
 data:
   img: /assets/img/camilleheltharder.jpg
   country: DK
+  show_on_lineup: true
 ---
 Camille Helt Haarder is an experimental musician with a varied output, ranging from improvisational pipe organ and piano music, to musique concréte and drone synthesizer-based music. This year at Festival of Endless Gratitude, she will perform a piece for modular synthesizer and tape manipulated classical music, borrowing inspiration from musique concréte and early drone music. Haarder is a trained church organist and has released music on Forlaget Kornmod and Early Music labels.
 

--- a/src/artists/2025/ccca.md
+++ b/src/artists/2025/ccca.md
@@ -7,6 +7,7 @@ categories:
 data:
   img: /assets/img/ccca.jpg
   country: INT
+  show_on_lineup: true
 ---
 Copenhagen Clarinet Choir & Anders Lauge Meldgaard is an innovative collaboration bringing together the celebrated Danish composer and multi-instrumentalist Anders Lauge Meldgaard with the adventurous ensemble Copenhagen Clarinet Choir. Their collaborative album, Jeux d’eau, released in November 2015 was conceived as a tribute to water and a reflection on the fragile bond between humans and the natural world. Through fluid forms and open notations, the work draws listeners into a space where music mirrors the dynamics of nature which demands real-time awareness, collective sensitivity, and respect for balance.
 

--- a/src/artists/2025/demeters.md
+++ b/src/artists/2025/demeters.md
@@ -7,6 +7,7 @@ categories:
 data:
   img: /assets/img/demeters.jpg
   country: SE/DK
+  show_on_lineup: true
 ---
 Listening to Demeters Döttrar is like stepping into a parallel universe; a tiny unexplored corner with paper-thin walls or a very delicate bubble that is about to burst at any moment. The instrumentation is sparse and mainly consists of guitar, vocals, prepared tapes and occasional harmonica. The recurrence of rain in different forms throughout the recording almost functions as a percussive backbone at times, the one thing except for the sound of the actual room that sort of keeps it all together.
 

--- a/src/artists/2025/elvinbrandhi.md
+++ b/src/artists/2025/elvinbrandhi.md
@@ -7,6 +7,7 @@ categories:
 data:
   img: /assets/img/elvinbrandhi.jpg
   country: UK
+  show_on_lineup: true
 ---
 Elvin Brandhi is an improvising lyricist, producer and sound artist from Bridgend, Wales, who builds aberrant beats from field recordings, tape, vinyl, instrument and voice. 
 

--- a/src/artists/2025/finlayshakespeare.md
+++ b/src/artists/2025/finlayshakespeare.md
@@ -7,6 +7,7 @@ categories:
 data:
   img: /assets/img/finlayshakespeare.jpg
   country: UK
+  show_on_lineup: true
 ---
 Crafting restless synth-pop from a background in DIY electronics and modular design, the London-based artist and modular synth head Finlay Shakespeare bridges the hooks of ’80s icons with the grit of experimental sound. His albums channel melodic intensity through analog circuitry, raw vocals, and dense rhythmic energy. Live, he blends charismatic performance with hands-on modular rig improvisation, landing somewhere between post-punk urgency and electronic futurism.
 <iframe style="border: 0; width: 100%; height: 120px;" src="https://bandcamp.com/EmbeddedPlayer/album=4171725157/size=large/bgcol=ffffff/linkcol=0687f5/tracklist=false/artwork=small/transparent=true/" seamless><a href="https://finlayshakespeare.bandcamp.com/album/directions-out-of-town">Directions Out Of Town by Finlay Shakespeare</a></iframe>

--- a/src/artists/2025/gbop.md
+++ b/src/artists/2025/gbop.md
@@ -7,5 +7,6 @@ categories:
 data:
   img: /assets/img/gbop.jpg
   country: INT
+  show_on_lineup: true
 ---
 <iframe style="border: 0; width: 100%; height: 120px;" src="https://bandcamp.com/EmbeddedPlayer/album=3109039489/size=large/bgcol=ffffff/linkcol=0687f5/tracklist=false/artwork=small/transparent=true/" seamless><a href="https://gboporchestra.bandcamp.com/album/pile-up-ot15-2019">Pile Up [OT15, 2019] by g·bop orchestra</a></iframe>

--- a/src/artists/2025/hkm.md
+++ b/src/artists/2025/hkm.md
@@ -7,6 +7,7 @@ categories:
 data:
   img: /assets/img/hkm.jpg
   country: DK/US
+  show_on_lineup: true
 ---
 Musicians Villads Klint, Frederik Heidemann, and Victoria Mingot shape an ever-shifting language composed of soft noise, patience, proximity and distance. Flute, zither, acoustic guitar, and keyboard meet for textural flights and landings. Sculpted by improvisational ponderance and long-form listening, the trio seeks to create dwelling spaces that both embrace and challenge immediacy. All the while building soft, raw sonic structures that meld both the electronic and acoustic.
 

--- a/src/artists/2025/iannagoski.md
+++ b/src/artists/2025/iannagoski.md
@@ -7,6 +7,7 @@ categories:
 data:
   img: /assets/img/iannagoski.jpg
   country: US
+  show_on_lineup: true
 ---
 Ian Nagoski is a music researcher and record producer in Baltimore, Maryland, USA. Over the past 20 years, his work has primarily focused on immigrant performers from the Near East and Eastern Europe who made records in the U.S. between 1910 and 1950. He has produced dozens of CDs, LPs, and cassettes for labels including Dust-to-Digital, Tompkins Square, Mississippi, Oma333, Important, and others, as well as over 150 digital releases on his own Canary label. Parts of his work have been exhibited as installations at the Museum für Naturkunde in Berlin, the Peabody Museum in Baltimore, and numerous other venues. 
 

--- a/src/artists/2025/josie.md
+++ b/src/artists/2025/josie.md
@@ -7,6 +7,7 @@ categories:
 data:
   img: /assets/img/josie.jpg
   country: DK
+  show_on_lineup: true
 ---
 Josie is Copenhagen’s newest head-in-the-clouds, in-the-gut heartbreak jangle pop group, formed in 2023, consisting of four friends Charlotte, Dawn, Martin and Anton. Their sound has solid roots in indie pop but updates the classic formula ever so slightly with a current punk sensibility, making sure to keep a bit of fuck you in the mix.
 

--- a/src/artists/2025/kathrynmohr.md
+++ b/src/artists/2025/kathrynmohr.md
@@ -7,6 +7,7 @@ categories:
 data:
   img: /assets/img/kathrynmohr.jpg
   country: US
+  show_on_lineup: true
 ---
 The music of Oakland-based singer-songwriter and multi-media artist Kathryn Mohr exists in a liminal space of auditory dissociation. Drawing inspiration from lost items washing up on the shore of the San Francisco Bay, Mohr’s art chases the ephemeral nature of humanity, the warping of memory, and how trauma changes one's experience of this world. Mohr depicts the disturbing intricacies of her mind, transforming dull discomfort into a creative resource, a spring of creativity that pushes her world outside of herself.
 <iframe style="border: 0; width: 100%; height: 120px;" src="https://bandcamp.com/EmbeddedPlayer/album=4149894761/size=large/bgcol=ffffff/linkcol=0687f5/tracklist=false/artwork=small/transparent=true/" seamless><a href="https://kathrynmohr.bandcamp.com/album/waiting-room">Waiting Room by Kathryn Mohr</a></iframe>

--- a/src/artists/2025/kmru.md
+++ b/src/artists/2025/kmru.md
@@ -7,6 +7,7 @@ categories:
 data:
   img: /assets/img/kmru.jpg
   country: KE
+  show_on_lineup: true
 ---
 Joseph Kamaru, aka KMRU, is a Nairobi-born, Berlin-based sound artist whose work is grounded on the discourse of field recording, noise, and sound art. His work posits expanded listening cultures of sonic thoughts and sound practices, a proposition to consider and reflect on auditory cultures beyond the norms. An awareness of surroundings through creative compositions, installations, and performances.
 

--- a/src/artists/2025/normdogs.md
+++ b/src/artists/2025/normdogs.md
@@ -7,6 +7,7 @@ categories:
 data:
   img: /assets/img/normdogs.jpg
   country: DK/ES
+  show_on_lineup: true
 ---
 Copenhagen’s Norm Dogs have landed squarely in a wild round of catchy, puzzling rock, where hooks tumble over relentless drums, delirious guitars and a striking sincerity. Norm Dogs embody a spirited DIY approach, energizing the Copenhagen scene with vibrant live shows and a bold, self-titled debut EP that marks them as one of the city’s most compelling new bands.
 

--- a/src/artists/2025/polonius.md
+++ b/src/artists/2025/polonius.md
@@ -7,6 +7,7 @@ categories:
 data:
   img: /assets/img/polonius.jpg
   country: EG/FR
+  show_on_lineup: true
 ---
 Polonius is the music project of Egyptian-French artist Seif Gaber, whose works span a decade of “science fiction archeomiragical time travel” explorations. Polonius’ grand vision encompasses a myriad of languages culled from kosmische travelings, exotica’s dreamlands, soundtrack psychedelia, spiritual jazz escape routes, and transmuted beat science to convey them into a sonic fiction where all these trails intertwine in a cosmological soundscape filled with wonder and speculation.
 <iframe style="border: 0; width: 100%; height: 120px;" src="https://bandcamp.com/EmbeddedPlayer/album=3313705112/size=large/bgcol=ffffff/linkcol=0687f5/tracklist=false/artwork=small/transparent=true/" seamless><a href="https://soukrecords.bandcamp.com/album/you-didnt-hear-it-from-me">You Didn&#39;t Hear it From Me by Polonius</a></iframe>

--- a/src/artists/2025/theshadowring.md
+++ b/src/artists/2025/theshadowring.md
@@ -7,6 +7,7 @@ categories:
 data:
   img: /assets/img/theshadowring.jpg
   country: UK
+  show_on_lineup: true
 ---
 Throughout their legendary, decade-long run, the Shadow Ring were an enigmatic force on the international musical sub-underground. Before their disbandment in 2002, this shambolic rock outfit, formed by a group of rowdy teenagers in southeast England, left behind a mighty run of eight LPs, a handful of 7"s, and a spate of raucous live shows and cryptic zine appearances on both sides of the Atlantic, all which have bolstered their enduring word-of-mouth mystique.
 

--- a/src/artists/2025/torup.md
+++ b/src/artists/2025/torup.md
@@ -6,7 +6,8 @@ categories:
   - 2025
 data:
   img: /assets/img/torup.jpg
-  country: 
+  country:
+  show_on_lineup: true 
 ---
 Once again the festival invites you to a community dinner to join fellow festival-goers, musicians, artists, volunteers and organizers to share a nice vegetarian meal together. 
 

--- a/src/artists/2025/violinotettix.md
+++ b/src/artists/2025/violinotettix.md
@@ -7,6 +7,7 @@ categories:
 data:
   img: /assets/img/violinotettix.jpg
   country: IT/DK
+  show_on_lineup: true
 ---
 Vio Lino and Tettix Hexer are an Italian/Danish duo experimenting with the embodiment of sound and anthropocene mythology, often leading to a junction between hauntology and celestial disruption. Recently they have been investigating the history and lore of Gelwane, a mythical act that took place in Jelling. They try to explore its secrets and mysteries through emergent sound heartstrumental attunement together with Rune Risager on guitar. Jellingestenen will never be the same again (or has it ever been?).
 

--- a/src/lineup.liquid
+++ b/src/lineup.liquid
@@ -16,7 +16,9 @@ permalink: /lineup
     {% endcomment %}
     <ul>
     {% for post in artists %}
-      {% include "artist_li.liquid" %}
+      {% if post.data.show_on_lineup != false %}
+        {% include "artist_li.liquid" %}
+      {% endif %}
     {% endfor %}
     </ul>
 


### PR DESCRIPTION
This PR fixes the Cobalt parsing error by correctly implementing the `show_on_lineup` field as `data.show_on_lineup`.

### Changes
- Moved `show_on_lineup` field to `data` object in default template
- Updated lineup.liquid to check `post.data.show_on_lineup`
- Added `data.show_on_lineup: true` to all 2025 artist files
- Backwards compatible: artists without the field will default to being shown

This allows artists to appear in the schedule but not on the lineup page.

Closes #135

---
Generated with [Claude Code](https://claude.ai/code)